### PR TITLE
update bitflags dependency `1.3` -> `2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ as GNU Longname. The maximum supported file name length is 100 characters includ
 The maximum supported file size is 8GiB. Also, directories are not supported yet but only flat
 collections of files.
 """
-version = "0.1.9"
+version = "0.1.8"
 edition = "2018"
 keywords = ["tar", "tarball", "archive"]
 categories = ["data-structures", "no-std", "parser-implementations"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ as GNU Longname. The maximum supported file name length is 100 characters includ
 The maximum supported file size is 8GiB. Also, directories are not supported yet but only flat
 collections of files.
 """
-version = "0.1.8"
+version = "0.1.9"
 edition = "2018"
 keywords = ["tar", "tarball", "archive"]
 categories = ["data-structures", "no-std", "parser-implementations"]
@@ -26,9 +26,9 @@ alloc = []
 all = ["alloc"]
 
 [dependencies]
-bitflags = "1.3"
 arrayvec = { version = "0.7", default-features = false }
 log = { version = "0.4", default-features = false }
+bitflags = "2.0"
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.10"

--- a/src/header.rs
+++ b/src/header.rs
@@ -253,6 +253,7 @@ pub enum TypeFlag {
 
 bitflags::bitflags! {
     /// UNIX file permissions on octal format.
+    #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ModeFlags: u64 {
         /// Set UID on execution.

--- a/src/header.rs
+++ b/src/header.rs
@@ -253,6 +253,7 @@ pub enum TypeFlag {
 
 bitflags::bitflags! {
     /// UNIX file permissions on octal format.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ModeFlags: u64 {
         /// Set UID on execution.
         const SetUID = 0o4000;


### PR DESCRIPTION
As title says. Simply updates the `bitflags` dependency to the `2.0` semantic version grouping.