### PR TITLE
improve lifetime of TarArchiveRef.entries

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -191,7 +191,7 @@ impl<'a> TarArchiveRef<'a> {
 
     /// Creates an [`ArchiveEntryIterator`].
     #[must_use]
-    pub fn entries(&self) -> ArchiveEntryIterator {
+    pub fn entries(&self) -> ArchiveEntryIterator<'a> {
         ArchiveEntryIterator::new(self.data)
     }
 }


### PR DESCRIPTION
right now the iterator needs to borrow the archive, but the true max valid lifetime is that of the underlying data since no state is actually maintained in the TarArchiveRef. this commit changes the output lifetime of the entries() func to the maximal one.