### PR TITLE
FIX: Ignore high bits in mode field

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -69,7 +69,7 @@ impl Mode {
     /// Returns [`ModeError`] for invalid values.
     pub fn to_flags(self) -> Result<ModeFlags, ModeError> {
         let bits = self.0.as_number::<u64>().map_err(ModeError::ParseInt)?;
-        ModeFlags::from_bits(bits).ok_or(ModeError::IllegalMode)
+        ModeFlags::from_bits(bits & 0o7777).ok_or(ModeError::IllegalMode)
     }
 }
 


### PR DESCRIPTION
Various tar libraries create incompatible mode fields with high bits set.
For example https://github.com/golang/go/issues/20150

We can use either:
- `from_bits_truncate` which ignores low incorrect bits; or
- clear the high bits before parsing `ModeFlags`, chosen here.
